### PR TITLE
Use string builder to reduce allocations

### DIFF
--- a/unidecode.go
+++ b/unidecode.go
@@ -19,11 +19,10 @@ func Unidecode(s string) string {
 }
 
 func unidecode(s string) string {
-	ret := []string{}
+	var ret strings.Builder
 	for _, r := range s {
 		if r < unicode.MaxASCII {
-			v := string(r)
-			ret = append(ret, v)
+			ret.WriteRune(r)
 			continue
 		}
 		if r > 0xeffff {
@@ -34,9 +33,9 @@ func unidecode(s string) string {
 		position := r % 256 // Last two hex digits
 		if tb, ok := table.Tables[section]; ok {
 			if len(tb) > int(position) {
-				ret = append(ret, tb[position])
+				ret.WriteString(tb[position])
 			}
 		}
 	}
-	return strings.Join(ret, "")
+	return ret.String()
 }

--- a/unidecode_test.go
+++ b/unidecode_test.go
@@ -58,7 +58,7 @@ func TestUnidecode(t *testing.T) {
 		{"PŘÍLIŠ ŽLUŤOUČKÝ KŮŇ PĚL ĎÁBELSKÉ ÓDY", "PRILIS ZLUTOUCKY KUN PEL DABELSKE ODY"},
 		{"\ua500", ""},
 		{"\u1eff", ""},
-		{string(0xfffff), ""},
+		{string(rune(0xfffff)), ""},
 		{"\U0001d5a0", "A"},
 		{"\U0001d5c4\U0001d5c6/\U0001d5c1", "km/h"},
 		{"\u2124\U0001d552\U0001d55c\U0001d552\U0001d55b \U0001d526\U0001d52a\U0001d51e \U0001d4e4\U0001d4f7\U0001d4f2\U0001d4ec\U0001d4f8\U0001d4ed\U0001d4ee \U0001d4c8\U0001d4c5\u212f\U0001d4b8\U0001d4be\U0001d4bb\U0001d4be\U0001d4c0\U0001d4b6\U0001d4b8\U0001d4be\U0001d4bf\u212f \U0001d59f\U0001d586 \U0001d631\U0001d62a\U0001d634\U0001d622\U0001d637\U0001d626?!", "Zakaj ima Unicode specifikacije za pisave?!"},


### PR DESCRIPTION
Hello, this pr uses strings.Builder instead of append to reduce the number of memory allocations.

Unidecode on string "üñíCöDÈ" repeated n times, with append:
```
cpu: AMD Ryzen 5 5600X 6-Core Processor             
BenchmarkUnidecode/go-unidecode_1-12             3358656               328.9 ns/op           256 B/op          7 allocs/op
BenchmarkUnidecode/go-unidecode_10-12             491061              2354 ns/op            4240 B/op         29 allocs/op
BenchmarkUnidecode/go-unidecode_100-12             64015             18734 ns/op           31440 B/op        212 allocs/op
BenchmarkUnidecode/go-unidecode_1000-12             4491            242756 ns/op          521266 B/op       2019 allocs/op
BenchmarkUnidecode/go-unidecode_10000-12             337           3411895 ns/op         5713300 B/op      20028 allocs/op
```
with strings.Builder:
```
cpu: AMD Ryzen 5 5600X 6-Core Processor             
BenchmarkUnidecode/go-unidecode_1-12            17364760                70.24 ns/op            8 B/op          1 allocs/op
BenchmarkUnidecode/go-unidecode_10-12            1610168               757.2 ns/op           248 B/op          5 allocs/op
BenchmarkUnidecode/go-unidecode_100-12            170352              6377 ns/op            1912 B/op          8 allocs/op
BenchmarkUnidecode/go-unidecode_1000-12            17743             68894 ns/op           34296 B/op         15 allocs/op
BenchmarkUnidecode/go-unidecode_10000-12            1668            760811 ns/op          285432 B/op         22 allocs/op
```